### PR TITLE
adding hessian restart

### DIFF
--- a/aiida_orca/__init__.py
+++ b/aiida_orca/__init__.py
@@ -1,3 +1,3 @@
 """AiiDA-Orca plugin"""
 
-__version__ = '0.1.0'
+__version__ = '0.2.0'

--- a/aiida_orca/parsers/__init__.py
+++ b/aiida_orca/parsers/__init__.py
@@ -11,7 +11,7 @@ import pymatgen as mp
 from aiida.parsers import Parser
 from aiida.common import OutputParsingError, NotExistent
 from aiida.engine import ExitCode
-from aiida.orm import Dict, StructureData
+from aiida.orm import Dict, SinglefileData, StructureData
 
 
 class OrcaBaseParser(Parser):
@@ -29,6 +29,7 @@ class OrcaBaseParser(Parser):
             return self.exit_codes.ERROR_NO_RETRIEVED_FOLDER
 
         fname = self.node.process_class._DEFAULT_OUTPUT_FILE  #pylint: disable=protected-access
+        hessian_fname = self.node.process_class._DEFAULT_HESSIAN_FILE  #pylint: disable=protected-access
 
         if fname not in out_folder._repository.list_object_names():  #pylint: disable=protected-access
             raise OutputParsingError('Orca output file not retrieved')
@@ -69,6 +70,10 @@ class OrcaBaseParser(Parser):
             results['frequencies'] = output_dict['vibfreqs'].tolist()
             results['IRS'] = output_dict['vibirs'].tolist()
             results['temperature'] = output_dict['temperature']
+            hessian = SinglefileData(
+                file=os.path.join(out_folder._repository._get_base_folder().abspath, hessian_fname)  #pylint: disable=protected-access
+            )
+            self.out('hessian', hessian)
 
         pt = PeriodicTable()  #pylint: disable=invalid-name
 

--- a/examples/example_opt_anfreq.py
+++ b/examples/example_opt_anfreq.py
@@ -1,0 +1,77 @@
+"""Run Opt and analytical Freq Calculation using AiiDA-Orca"""
+
+import sys
+import click
+
+import pymatgen as mg
+
+from aiida.engine import run_get_pk
+from aiida.orm import (Code, Dict, StructureData)
+from aiida.common import NotExistent
+from aiida.plugins import CalculationFactory
+
+OrcaCalculation = CalculationFactory('orca')  #pylint: disable = invalid-name
+
+
+def example_opt_anfreq(orca_code, submit=True):
+    """Run Opt and analytical Calculation using AiiDA-Orca"""
+
+    # structure
+    structure = StructureData(pymatgen_molecule=mg.Molecule.from_file('./ch4.xyz'))
+
+    # parameters
+    parameters = Dict(
+        dict={
+            'charge': 0,
+            'multiplicity': 1,
+            'input_blocks': {
+                'scf': {
+                    'convergence': 'tight',
+                },
+                'pal': {
+                    'nproc': 2,
+                }
+            },
+            'input_kewords': ['RKS', 'BP', 'def2-TZVP', 'RI', 'def2/J'],
+            'extra_input_keywords': ['Grid5', 'NoFinalGrid', 'AnFreq', 'OPT'],
+        }
+    )
+
+    # Construct process builder
+
+    builder = OrcaCalculation.get_builder()
+
+    builder.structure = structure
+    builder.parameters = parameters
+    builder.code = orca_code
+
+    builder.metadata.options.resources = {
+        'num_machines': 1,
+        'num_mpiprocs_per_machine': 2,
+    }
+    builder.metadata.options.max_wallclock_seconds = 1 * 3 * 60
+    if submit:
+        print('Testing ORCA Opt and analytical Calculation...')
+        res, pk = run_get_pk(builder)
+        print('calculation pk: ', pk)
+        print('Enthalpy is :', res['output_parameters'].dict['enthalpy'])
+    else:
+        builder.metadata.dry_run = True
+        builder.metadata.store_provenance = False
+
+
+@click.command('cli')
+@click.argument('codelabel')
+@click.option('--submit', is_flag=True, help='Actually submit calculation')
+def cli(codelabel, submit):
+    """Click interface"""
+    try:
+        code = Code.get_from_string(codelabel)
+    except NotExistent:
+        print("The code '{}' does not exist".format(codelabel))
+        sys.exit(1)
+    example_opt_anfreq(code, submit)
+
+
+if __name__ == '__main__':
+    cli()  # pylint: disable=no-value-for-parameter

--- a/examples/example_opt_numfreq.py
+++ b/examples/example_opt_numfreq.py
@@ -1,0 +1,77 @@
+"""Run Opt and Numerical Freq Calculation using AiiDA-Orca"""
+
+import sys
+import click
+
+import pymatgen as mg
+
+from aiida.engine import run_get_pk
+from aiida.orm import (Code, Dict, StructureData)
+from aiida.common import NotExistent
+from aiida.plugins import CalculationFactory
+
+OrcaCalculation = CalculationFactory('orca')  #pylint: disable = invalid-name
+
+
+def example_opt_numfreq(orca_code, submit=True):
+    """Run Opt and Numerical Calculation using AiiDA-Orca"""
+
+    # structure
+    structure = StructureData(pymatgen_molecule=mg.Molecule.from_file('./ch4.xyz'))
+
+    # parameters
+    parameters = Dict(
+        dict={
+            'charge': 0,
+            'multiplicity': 1,
+            'input_blocks': {
+                'scf': {
+                    'convergence': 'tight',
+                },
+                'pal': {
+                    'nproc': 2,
+                }
+            },
+            'input_kewords': ['RKS', 'BP', 'def2-TZVP', 'RI', 'def2/J'],
+            'extra_input_keywords': ['Grid5', 'NoFinalGrid', 'NumFreq', 'OPT'],
+        }
+    )
+
+    # Construct process builder
+
+    builder = OrcaCalculation.get_builder()
+
+    builder.structure = structure
+    builder.parameters = parameters
+    builder.code = orca_code
+
+    builder.metadata.options.resources = {
+        'num_machines': 1,
+        'num_mpiprocs_per_machine': 2,
+    }
+    builder.metadata.options.max_wallclock_seconds = 1 * 3 * 60
+    if submit:
+        print('Testing ORCA and Numerical Frequency Calculation...')
+        res, pk = run_get_pk(builder)
+        print('calculation pk: ', pk)
+        print('Enthalpy is :', res['output_parameters'].dict['enthalpy'])
+    else:
+        builder.metadata.dry_run = True
+        builder.metadata.store_provenance = False
+
+
+@click.command('cli')
+@click.argument('codelabel')
+@click.option('--submit', is_flag=True, help='Actually submit calculation')
+def cli(codelabel, submit):
+    """Click interface"""
+    try:
+        code = Code.get_from_string(codelabel)
+    except NotExistent:
+        print("The code '{}' does not exist".format(codelabel))
+        sys.exit(1)
+    example_opt_numfreq(code, submit)
+
+
+if __name__ == '__main__':
+    cli()  # pylint: disable=no-value-for-parameter

--- a/setup.json
+++ b/setup.json
@@ -14,7 +14,7 @@
         "License :: OSI Approved :: MIT License",
         "Framework :: AiiDA"
     ],
-    "version": "0.1.0",
+    "version": "0.2.0",
     "setup_requires": ["reentry"],
     "install_requires": [
         "aiida_core[atomic_tools] >= 1.0.0, <2.0.0",


### PR DESCRIPTION
This PR aims to address the remaining part of #3 
The usage of `gbw` files to read initial guess for restarting for example geometry optimizations was addressed in #9 
Herein, it is extended to using `Hessian` files and comes with following changes:
* In the case of running `frequency` calculation, resulting `Hessian` will be part of the the `output` as `hessian`. So far, I did not find whether it is possible to provide absolute path instead of copying actual `Hessian` in `ORCA`. It means that whatever happens, we need to copy the old `Hessian` to the next calculation folder. 
* The old `Hessian` can be served as the input of new calculation to restart a crashed calculation or recalculating thermochemistry part at different temperature part, for instance. 