### PR TITLE
generalization of output + adding tddft example

### DIFF
--- a/examples/example_1.py
+++ b/examples/example_1.py
@@ -67,7 +67,7 @@ def example_opt_restart(orca_code, opt_calc_pk=None, submit=True):
         print('Testing Orca Opt Calculations...')
         res, pk = run_get_pk(builder)
         print('calculation pk: ', pk)
-        print('SCF Energy is :', res['output_parameters'].dict['SCF_energies'])
+        print('SCF Energy is :', res['output_parameters'].dict['scfenergies'])
     else:
         builder.metadata.dry_run = True
         builder.metadata.store_provenance = False

--- a/examples/example_4.py
+++ b/examples/example_4.py
@@ -1,25 +1,23 @@
-"""Run simple DFT calculation"""
-import os
+"""Run simple TDDFT Calculation using AiiDA-Orca"""
+
 import sys
 import click
 import pytest
-import pymatgen as mg
 
 from aiida.engine import run_get_pk
-from aiida.orm import (Code, Dict, StructureData)
+from aiida.orm import load_node, Code, Dict
 from aiida.common import NotExistent
 from aiida.plugins import CalculationFactory
 
 OrcaCalculation = CalculationFactory('orca')  #pylint: disable = invalid-name
 
 
-def example_opt(orca_code, submit=True):
-    """Run simple DFT calculation"""
+def example_simple_tddft(orca_code, opt_calc_pk=None, submit=True):
+    """Run simple TDDFT Calculation using AiiDA-Orca"""
 
-    # structure
-    thisdir = os.path.dirname(os.path.realpath(__file__))
-    xyz_path = os.path.join(thisdir, 'h2co.xyz')
-    structure = StructureData(pymatgen_molecule=mg.Molecule.from_file(xyz_path))
+    # This line is needed for tests only
+    if opt_calc_pk is None:
+        opt_calc_pk = pytest.opt_calc_pk  # pylint: disable=no-member
 
     # parameters
     parameters = Dict(
@@ -30,34 +28,36 @@ def example_opt(orca_code, submit=True):
                 'scf': {
                     'convergence': 'tight',
                 },
-                'pal': {  #Uncomment for parallel run.
+                'pal': {
                     'nproc': 2,
+                },
+                'tddft': {
+                    'nroots': 8,
+                    'maxdim': 2,
+                    'triplets': 'true',
                 }
             },
-            'input_keywords': ['B3LYP/G', 'SV(P)', 'Opt'],
+            'input_kewords': ['RKS', 'B3LYP/G', 'SV(P)'],
             'extra_input_keywords': [],
         }
     )
 
     # Construct process builder
-
     builder = OrcaCalculation.get_builder()
 
-    builder.structure = structure
+    builder.structure = load_node(opt_calc_pk).outputs.relaxed_structure
     builder.parameters = parameters
     builder.code = orca_code
-
     builder.metadata.options.resources = {
         'num_machines': 1,
         'num_mpiprocs_per_machine': 1,
     }
     builder.metadata.options.max_wallclock_seconds = 1 * 10 * 60
     if submit:
-        print('Testing Orca Opt Calculations...')
+        print('Testing ORCA  simple TDDFT Calculation...')
         res, pk = run_get_pk(builder)
         print('calculation pk: ', pk)
-        print('SCF Energy is :', res['output_parameters'].dict['scfenergies'])
-        pytest.opt_calc_pk = pk
+        print('1st ET energy is :', res['output_parameters'].dict['etenergies'][0])
     else:
         builder.metadata.dry_run = True
         builder.metadata.store_provenance = False
@@ -65,15 +65,16 @@ def example_opt(orca_code, submit=True):
 
 @click.command('cli')
 @click.argument('codelabel')
+@click.option('--previous_calc', '-p', required=True, type=int, help='PK of example_2.py calculation')
 @click.option('--submit', is_flag=True, help='Actually submit calculation')
-def cli(codelabel, submit):
+def cli(codelabel, previous_calc, submit):
     """Click interface"""
     try:
         code = Code.get_from_string(codelabel)
     except NotExistent:
         print("The code '{}' does not exist".format(codelabel))
         sys.exit(1)
-    example_opt(code, submit)
+    example_simple_tddft(code, previous_calc, submit)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR aims to:
* replace the tiny parsing of `cclib` in plugin parser with full parsed data. Initially, I have done that the other way as there was an issue storing dictionary with `nan` values. For more detail see:
https://github.com/aiidateam/aiida-core/issues/3450
https://github.com/aiidateam/aiida-core/issues/2412
I have put a function in parser which removes such values and therefore, decided to have all parsed data by `cclib` stored in `output_parameters`. Then, we can do more parsing and filtering and any other logic at the workchain level. 

* It also solves #17 