### PR TITLE
Fix pymatgen imports

### DIFF
--- a/aiida_orca/parsers/__init__.py
+++ b/aiida_orca/parsers/__init__.py
@@ -6,7 +6,7 @@ import numpy as np
 from cclib import io
 from cclib.parser.utils import PeriodicTable
 
-import pymatgen as mp
+from pymatgen.core.structure import Molecule
 
 from aiida.parsers import Parser
 from aiida.common import OutputParsingError, NotExistent
@@ -76,7 +76,7 @@ class OrcaBaseParser(Parser):
 
         if opt_run:
             relaxed_structure = StructureData(
-                pymatgen_molecule=mp.Molecule.
+                pymatgen_molecule=Molecule.
                 from_file(os.path.join(out_folder._repository._get_base_folder().abspath, fname_relaxed))  #pylint: disable=protected-access
             )
             # relaxation_trajectory = SinglefileData(

--- a/examples/example_0.py
+++ b/examples/example_0.py
@@ -3,8 +3,9 @@ import os
 import sys
 import click
 import pytest
-import pymatgen as mg
+import pymatgen.core.structure as mg
 
+import aiida
 from aiida.engine import run_get_pk
 from aiida.orm import (Code, Dict, StructureData)
 from aiida.common import NotExistent
@@ -69,6 +70,7 @@ def example_opt(orca_code, submit=True):
 def cli(codelabel, submit):
     """Click interface"""
     try:
+        aiida.load_profile()
         code = Code.get_from_string(codelabel)
     except NotExistent:
         print("The code '{}' does not exist".format(codelabel))

--- a/examples/example_1.py
+++ b/examples/example_1.py
@@ -4,7 +4,7 @@ import sys
 import click
 import pytest
 
-import pymatgen as mg
+import pymatgen.core.structure as mg
 
 from aiida.engine import run_get_pk
 from aiida.orm import load_node, Code, Dict, SinglefileData, StructureData

--- a/examples/example_2.py
+++ b/examples/example_2.py
@@ -3,7 +3,6 @@ import os
 import sys
 import click
 import pytest
-import pymatgen as mg
 
 from aiida.engine import run_get_pk
 from aiida.orm import (Code, Dict, StructureData)

--- a/examples/example_5.py
+++ b/examples/example_5.py
@@ -3,7 +3,7 @@ import os
 import sys
 import click
 import pytest
-import pymatgen as mg
+import pymatgen.core.structure as mg
 
 from aiida.engine import run_get_pk
 from aiida.orm import (Code, Dict, StructureData)


### PR DESCRIPTION
It looks like `from pymatgen import Molecule` import has been deprecated in pymatgen
[v2022](https://github.com/materialsproject/pymatgen/blob/master/CHANGES.rst#v202200-yanked)

> Root-level imports have been removed. Please see https://pymatgen.org/compatibility.html on how to update your code for compatibility with v2022.

The full path import introduced here should be hopefully backward compatible.