### PR TITLE
Set minimum cclib version to support ORCA 5.0

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -18,7 +18,7 @@
     "setup_requires": ["reentry"],
     "install_requires": [
         "aiida_core[atomic_tools] >= 1.0.0, <2.0.0",
-        "cclib"
+        "cclib >= 1.7.2"
     ],
     "entry_points": {
         "aiida.calculations": [


### PR DESCRIPTION
New version 1.7.2 was finally released couple days ago that supports ORCA-5.0. I am setting this as a minimum version in `setup.json`.

Closes #26 

CC @pzarabadip 

PS: It would perhaps be nice to convert `setup.json` to the more modern `setup.cfg` approach.