### PR TITLE
Bring back conftest.py for tests in examples/

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-
-
-
 ![logo](./miscellaneous/aiida-orca_logo.png)
 
 # aiida-orca
@@ -28,8 +25,9 @@ Compatible with:
 
 
 # Installation
+
+Instalation from PyPI
 ```console
-git clone https://github.com/pzarabadip/aiida-orca
 pip install aiida-orca
 ```
 
@@ -47,9 +45,19 @@ It is recommended to install `pre-commit` such the pre-commit hooks are automati
 ```console
 pre-commit install
 ```
-To run the tests, run:
+To run the unit tests, run:
 ```console
-pytest
+pytest tests/
+```
+
+To run the end-to-end tests, that require the ORCA package installed, run:
+```console
+pytest examples/
+```
+
+or using multiple cores with OpenMPI parallelization
+```console
+pytest --nproc 2 examples/
 ```
 
 ## `pytest-regressions`

--- a/examples/conftest.py
+++ b/examples/conftest.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+"""
+For pytest initialise a test database and profile
+"""
+import pytest
+
+pytest_plugins = ['aiida.manage.tests.pytest_fixtures']  # pylint: disable=invalid-name
+
+
+def pytest_addoption(parser):
+    """Add cmdline options to pytest"""
+    parser.addoption('--nproc', action='store', default=1)
+
+
+@pytest.fixture(scope='function')
+def orca_code(aiida_local_code_factory):  # pylint: disable=unused-argument
+    """Fixture for fetching Orca Code node from AiiDA DB"""
+    return aiida_local_code_factory('orca', 'orca')
+
+
+@pytest.fixture(scope='session')
+def nproc(request):
+    """Fixture for number of CPUs"""
+    return request.config.option.nproc if request.config.option.nproc else 2

--- a/examples/pytest.ini
+++ b/examples/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+python_files = example_*.py
+python_functions = example_*


### PR DESCRIPTION
Tests in the `example/` directory require ORCA to be installed so they cannot be run in CI, but it is still useful to be able to run them manually.