### PR TITLE
Remove Pymatgen dependency, use ASE to read/write XYZ files

### DIFF
--- a/aiida_orca/calculations/orca_orca.py
+++ b/aiida_orca/calculations/orca_orca.py
@@ -122,25 +122,11 @@ class OrcaCalculation(CalcJob):
 
         return calcinfo
 
-    @staticmethod
-    def _write_structure(structure, folder: Folder, name: str) -> None:
-        """Function that writes a structure and takes care of element tags"""
+    def _write_structure(self, structure: StructureData, folder: Folder, filename: str) -> None:
+        """Function that writes a structure to a file in an XYZ format"""
 
-        # create file with the structure
-        mol = structure.get_pymatgen_molecule()
-
-        # from https://github.com/materialsproject/pymatgen/blob/
-        # 5a3284fd2dce70ee27e8291e6558e73beaba5164/pymatgen/io/gaussian.py#L411
-        def to_string(num):
-            return '%0.6f' % num
-
-        coords = []
-        for site in mol:
-            coords.append(' '.join([site.species_string, ' '.join([to_string(j) for j in site.coords])]))
-
-        with open(folder.get_abs_path(name), mode='w', encoding='utf-8') as fobj:
-            fobj.write('{}\n\n'.format(len(coords)))
-            fobj.write('\n'.join(coords))
-
-
-#EOF
+        # create file with the XYZ structure
+        ase_struct = structure.get_ase()
+        # ORCA cannot read the extended XYZ format, hence plain=True is needed.
+        # https://wiki.fysik.dtu.dk/ase/ase/io/formatoptions.html#ase.io.extxyz.write_extxyz
+        ase_struct.write(folder.get_abs_path(filename), format='extxyz', plain=True)

--- a/aiida_orca/calculations/orca_orca.py
+++ b/aiida_orca/calculations/orca_orca.py
@@ -122,7 +122,8 @@ class OrcaCalculation(CalcJob):
 
         return calcinfo
 
-    def _write_structure(self, structure: StructureData, folder: Folder, filename: str) -> None:
+    @staticmethod
+    def _write_structure(structure: StructureData, folder: Folder, filename: str) -> None:
         """Function that writes a structure to a file in an XYZ format"""
 
         # create file with the XYZ structure

--- a/aiida_orca/parsers/__init__.py
+++ b/aiida_orca/parsers/__init__.py
@@ -74,7 +74,7 @@ class OrcaBaseParser(Parser):
         output_dict = _remove_nan(parsed_dict)
 
         if parsed_dict.get('optdone', False):
-            # TODO: Change this when we drop AiiDA 1.x support
+            # Change this when we drop AiiDA 1.x support
             #with out_folder.base.repository.open(fname_relaxed) as handler:
             with out_folder.open(fname_relaxed) as handler:
                 ase_structure = ase.io.read(handler, format='xyz', index=0)

--- a/aiida_orca/parsers/__init__.py
+++ b/aiida_orca/parsers/__init__.py
@@ -4,9 +4,8 @@ import pathlib
 import shutil
 import tempfile
 
+import ase.io
 import numpy as np
-
-from pymatgen.core import Molecule
 
 from aiida.parsers import Parser
 from aiida.common import OutputParsingError, NotExistent
@@ -75,11 +74,17 @@ class OrcaBaseParser(Parser):
         output_dict = _remove_nan(parsed_dict)
 
         if parsed_dict.get('optdone', False):
-            with out_folder.open(fname_relaxed, 'rb') as handle:
-                with tempfile.NamedTemporaryFile('w+b', suffix=pathlib.Path(fname_relaxed).suffix) as tmpfile:
-                    shutil.copyfileobj(handle, tmpfile)
-                    tmpfile.flush()
-                    relaxed_structure = StructureData(pymatgen_molecule=Molecule.from_file(tmpfile.name))
+            # TODO: Change this when we drop AiiDA 1.x support
+            #with out_folder.base.repository.open(fname_relaxed) as handler:
+            with out_folder.open(fname_relaxed) as handler:
+                ase_structure = ase.io.read(handler, format='xyz', index=0)
+                if not ase_structure:
+                    self.logger.error(f'Could not read structure from output file {fname_relaxed}')
+                    return self.exit_codes.ERROR_OUTPUT_PARSING
+                # Temporary hack to support AiiDA 1.x, which needs default cell
+                # even for non-periodic structures.
+                ase_structure.set_cell([1.0, 1.0, 1.0])
+                relaxed_structure = StructureData(ase=ase_structure)
             self.out('relaxed_structure', relaxed_structure)
 
         pt = PeriodicTable()  # pylint: disable=invalid-name

--- a/aiida_orca/parsers/__init__.py
+++ b/aiida_orca/parsers/__init__.py
@@ -78,13 +78,13 @@ class OrcaBaseParser(Parser):
             #with out_folder.base.repository.open(fname_relaxed) as handler:
             with out_folder.open(fname_relaxed) as handler:
                 ase_structure = ase.io.read(handler, format='xyz', index=0)
-                if not ase_structure:
-                    self.logger.error(f'Could not read structure from output file {fname_relaxed}')
-                    return self.exit_codes.ERROR_OUTPUT_PARSING
-                # Temporary hack to support AiiDA 1.x, which needs default cell
-                # even for non-periodic structures.
-                ase_structure.set_cell([1.0, 1.0, 1.0])
-                relaxed_structure = StructureData(ase=ase_structure)
+            if not ase_structure:
+                self.logger.error(f'Could not read structure from output file {fname_relaxed}')
+                return self.exit_codes.ERROR_OUTPUT_PARSING
+            # Temporary hack to support AiiDA 1.x, which needs default cell
+            # even for non-periodic structures.
+            ase_structure.set_cell([1.0, 1.0, 1.0])
+            relaxed_structure = StructureData(ase=ase_structure)
             self.out('relaxed_structure', relaxed_structure)
 
         pt = PeriodicTable()  # pylint: disable=invalid-name

--- a/aiida_orca/parsers/__init__.py
+++ b/aiida_orca/parsers/__init__.py
@@ -75,9 +75,9 @@ class OrcaBaseParser(Parser):
 
         if parsed_dict.get('optdone', False):
             # Change this when we drop AiiDA 1.x support
-            #with out_folder.base.repository.open(fname_relaxed) as handler:
-            with out_folder.open(fname_relaxed) as handler:
-                ase_structure = ase.io.read(handler, format='xyz', index=0)
+            #with out_folder.base.repository.open(fname_relaxed) as handle:
+            with out_folder.open(fname_relaxed) as handle:
+                ase_structure = ase.io.read(handle, format='xyz', index=0)
             if not ase_structure:
                 self.logger.error(f'Could not read structure from output file {fname_relaxed}')
                 return self.exit_codes.ERROR_OUTPUT_PARSING

--- a/examples/example_1.py
+++ b/examples/example_1.py
@@ -5,7 +5,7 @@ import sys
 import click
 import pytest
 
-from pymatgen.core import Molecule
+import ase.io
 
 from aiida.engine import run_get_pk
 from aiida.orm import load_node, Code, Dict, SinglefileData, StructureData
@@ -25,12 +25,14 @@ def example_opt_restart(orca_code, nproc, submit=True, opt_calc_pk=None):
     # structure
     thisdir = os.path.dirname(os.path.realpath(__file__))
     xyz_path = os.path.join(thisdir, 'h2co.xyz')
-    structure = StructureData(pymatgen_molecule=Molecule.from_file(xyz_path))
+    ase_struct = ase.io.read(xyz_path, format='xyz', index=0)
+    ase_struct.set_cell([1.0, 1.0, 1.0])
+    structure = StructureData(ase=ase_struct)
 
     # old gbw file
     retr_fldr = load_node(opt_calc_pk).outputs.retrieved
-    with retr_fldr.open('aiida.gbw') as handler:
-        gbw_file = SinglefileData(handler.name)
+    with retr_fldr.open('aiida.gbw', 'rb') as handler:
+        gbw_file = SinglefileData(handler)
 
     # parameters
     parameters = Dict(
@@ -46,7 +48,7 @@ def example_opt_restart(orca_code, nproc, submit=True, opt_calc_pk=None):
                     'nproc': nproc,
                 },
             },
-            'input_keywords': ['PBE', 'def2-TZVP', 'Opt'],
+            'input_keywords': ['PBE', 'def2-SVP', 'Opt'],
             'extra_input_keywords': ['MOREAD'],
         }
     )
@@ -62,14 +64,15 @@ def example_opt_restart(orca_code, nproc, submit=True, opt_calc_pk=None):
     }
     builder.metadata.options.resources = {
         'num_machines': 1,
-        'num_mpiprocs_per_machine': 1,
+        'num_mpiprocs_per_machine': nproc,
     }
     builder.metadata.options.max_wallclock_seconds = 1 * 10 * 60
     if submit:
         print('Testing Orca single point calculation...')
         res, pk = run_get_pk(builder)
-        print('calculation pk: ', pk)
-        print('SCF Energy is :', res['output_parameters'].dict['scfenergies'])
+        print(f'Calculation PK: {pk}')
+        print(f'Optimized structure PK: {res["relaxed_structure"].pk}')
+        print(f'SCF Energy: {res["output_parameters"]["scfenergies"]}')
     else:
         builder.metadata.dry_run = True
         builder.metadata.store_provenance = False
@@ -88,7 +91,7 @@ def cli(codelabel, nproc, previous_calc, submit):
     except NotExistent:
         print(f'The code {codelabel} does not exist.')
         sys.exit(1)
-    example_opt_restart(code, nproc, previous_calc, submit)
+    example_opt_restart(code, nproc, submit, previous_calc)
 
 
 if __name__ == '__main__':

--- a/examples/example_1.py
+++ b/examples/example_1.py
@@ -31,8 +31,8 @@ def example_opt_restart(orca_code, nproc, submit=True, opt_calc_pk=None):
 
     # old gbw file
     retr_fldr = load_node(opt_calc_pk).outputs.retrieved
-    with retr_fldr.open('aiida.gbw', 'rb') as handler:
-        gbw_file = SinglefileData(handler)
+    with retr_fldr.open('aiida.gbw', 'rb') as handle:
+        gbw_file = SinglefileData(handle)
 
     # parameters
     parameters = Dict(

--- a/examples/example_2.py
+++ b/examples/example_2.py
@@ -5,10 +5,10 @@ import sys
 import click
 import pytest
 
-from pymatgen.core import Molecule
+import ase.io
 
 from aiida.engine import run_get_pk
-from aiida.orm import (Code, Dict, StructureData)
+from aiida.orm import Code, Dict, StructureData
 from aiida.common import NotExistent
 from aiida.plugins import CalculationFactory
 
@@ -21,7 +21,9 @@ def example_opt_numfreq(orca_code, nproc, submit=True):
     # structure
     thisdir = os.path.dirname(os.path.realpath(__file__))
     xyz_path = os.path.join(thisdir, 'h2co.xyz')
-    structure = StructureData(pymatgen_molecule=Molecule.from_file(xyz_path))
+    ase_struct = ase.io.read(xyz_path, format='xyz', index=0)
+    ase_struct.set_cell([1.0, 1.0, 1.0])
+    structure = StructureData(ase=ase_struct)
 
     # parameters
     parameters = Dict(
@@ -36,8 +38,8 @@ def example_opt_numfreq(orca_code, nproc, submit=True):
                     'nproc': nproc,
                 },
             },
-            'input_keywords': ['RKS', 'BP', 'def2-SVP', 'RI', 'def2/J'],
-            'extra_input_keywords': ['NumFreq', 'OPT'],
+            'input_keywords': ['RKS', 'BP', 'STO-3G'],
+            'extra_input_keywords': ['AnFreq', 'OPT'],
         }
     )
 
@@ -51,14 +53,20 @@ def example_opt_numfreq(orca_code, nproc, submit=True):
 
     builder.metadata.options.resources = {
         'num_machines': 1,
-        'num_mpiprocs_per_machine': 1,
+        'num_mpiprocs_per_machine': nproc,
     }
     builder.metadata.options.max_wallclock_seconds = 1 * 10 * 60
     if submit:
         print('Testing ORCA and Numerical Frequency Calculation...')
         res, pk = run_get_pk(builder)
-        print('calculation pk: ', pk)
-        print('Enthalpy is :', res['output_parameters'].dict['enthalpy'])
+        output = res['output_parameters']
+        print(f'calculation pk: {pk}')
+        print(f'Frequencies: {output["vibfreqs"]}')
+        print(f'Temperature: {output["temperature"]}')
+        print(f'Zero-point energy: {output["zpve"]}')
+        print(f'Enthalpy: {output["enthalpy"]}')
+        print(f'Entropy: {output["entropy"]}')
+        print(f'Free energy: {output["freeenergy"]}')
         pytest.freq_calc_pk = pk
     else:
         builder.metadata.dry_run = True

--- a/examples/example_3.py
+++ b/examples/example_3.py
@@ -21,8 +21,8 @@ def example_restart_anfreq(orca_code, nproc, submit=True, freq_calc_pk=None):
 
     # old hess file
     retr_fldr = load_node(freq_calc_pk).outputs.retrieved
-    with retr_fldr.open('aiida.hess', 'rb') as handler:
-        hess_file = SinglefileData(handler)
+    with retr_fldr.open('aiida.hess', 'rb') as handle:
+        hess_file = SinglefileData(handle)
 
     # parameters
     parameters = Dict(

--- a/examples/example_4.py
+++ b/examples/example_4.py
@@ -50,8 +50,8 @@ def example_simple_tddft(orca_code, nproc, submit=True, opt_calc_pk=None):
     # old gbw file
     opt_calc = load_node(opt_calc_pk)
     retr_fldr = opt_calc.outputs.retrieved
-    with retr_fldr.open('aiida.gbw', 'rb') as handler:
-        gbw_file = SinglefileData(handler)
+    with retr_fldr.open('aiida.gbw', 'rb') as handle:
+        gbw_file = SinglefileData(handle)
 
     builder.structure = opt_calc.outputs.relaxed_structure
     builder.parameters = parameters

--- a/examples/example_4.py
+++ b/examples/example_4.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-"""Run simple TDDFT Calculation using AiiDA-Orca"""
+"""Run a simple TDDFT Calculation using AiiDA-Orca"""
 
 import sys
 import click
 import pytest
 
 from aiida.engine import run_get_pk
-from aiida.orm import load_node, Code, Dict
+from aiida.orm import load_node, Code, Dict, SinglefileData
 from aiida.common import NotExistent
 from aiida.plugins import CalculationFactory
 
@@ -28,17 +28,18 @@ def example_simple_tddft(orca_code, nproc, submit=True, opt_calc_pk=None):
             'input_blocks': {
                 'scf': {
                     'convergence': 'tight',
+                    'moinp': '"aiida_old.gbw"',
                 },
                 'pal': {
                     'nproc': nproc,
                 },
                 'tddft': {
-                    'nroots': 8,
-                    'maxdim': 2,
-                    'triplets': 'true',
-                }
+                    'nroots': 3,
+                    'triplets': 'false',
+                    'tda': 'true',
+                },
             },
-            'input_keywords': ['RKS', 'PBE', 'SV(P)'],
+            'input_keywords': ['RKS', 'BP', 'STO-3G', 'MOREAD'],
             'extra_input_keywords': [],
         }
     )
@@ -46,20 +47,29 @@ def example_simple_tddft(orca_code, nproc, submit=True, opt_calc_pk=None):
     # Construct process builder
     builder = OrcaCalculation.get_builder()
 
-    builder.structure = load_node(opt_calc_pk).outputs.relaxed_structure
+    # old gbw file
+    opt_calc = load_node(opt_calc_pk)
+    retr_fldr = opt_calc.outputs.retrieved
+    with retr_fldr.open('aiida.gbw', 'rb') as handler:
+        gbw_file = SinglefileData(handler)
+
+    builder.structure = opt_calc.outputs.relaxed_structure
     builder.parameters = parameters
     builder.code = orca_code
+    builder.file = {
+        'gbw': gbw_file,
+    }
     builder.metadata.options.resources = {
         'num_machines': 1,
-        'num_mpiprocs_per_machine': 1,
+        'num_mpiprocs_per_machine': nproc,
     }
     builder.metadata.options.max_wallclock_seconds = 1 * 10 * 60
     if submit:
-        print('Testing ORCA  simple TDDFT Calculation...')
+        print('Testing TDDFT calculation...')
         res, pk = run_get_pk(builder)
-        print('calculation pk: ', pk)
-        print('1st ET energy is :', res['output_parameters'].dict['etenergies'][0])
-        print('1st oscillator strength energy is :', res['output_parameters'].dict['etoscs'][0])
+        print(f'calculation pk: {pk}')
+        print(f'1st excited state energy in cm^-1 is: {res["output_parameters"].dict["etenergies"][0]}')
+        print(f'1st oscillator strength is: {res["output_parameters"].dict["etoscs"][0]}')
     else:
         builder.metadata.dry_run = True
         builder.metadata.store_provenance = False
@@ -78,7 +88,7 @@ def cli(codelabel, nproc, previous_calc, submit):
     except NotExistent:
         print(f'The code {codelabel} does not exist.')
         sys.exit(1)
-    example_simple_tddft(code, nproc, previous_calc, submit)
+    example_simple_tddft(code, nproc, submit, previous_calc)
 
 
 if __name__ == '__main__':

--- a/examples/example_5.py
+++ b/examples/example_5.py
@@ -52,7 +52,7 @@ def example_opt(orca_code, nproc, submit=True):
     }
     builder.orca.metadata.options.max_wallclock_seconds = 1 * 10 * 60
     if submit:
-        print('Testing basic Orca workflow...')
+        print('Testing OrcaBaseWorkChain...')
         res, pk = run_get_pk(builder)
         calc = load_node(pk)
         if not calc.is_finished_ok:

--- a/examples/example_5.py
+++ b/examples/example_5.py
@@ -3,25 +3,26 @@
 import os
 import sys
 import click
-import pytest
 
-from pymatgen.core import Molecule
+import ase.io
 
 from aiida.engine import run_get_pk
-from aiida.orm import (Code, Dict, StructureData)
+from aiida.orm import load_node, Code, Dict, StructureData
 from aiida.common import NotExistent
 from aiida.plugins import WorkflowFactory
 
-OrcaBaseWorkChain = WorkflowFactory('orca.base')  #pylint: disable = invalid-name
+OrcaBaseWorkChain = WorkflowFactory('orca.base')
 
 
 def example_opt(orca_code, nproc, submit=True):
-    """Run simple DFT calculation"""
+    """Run basic workflow"""
 
     # structure
     thisdir = os.path.dirname(os.path.realpath(__file__))
     xyz_path = os.path.join(thisdir, 'h2co.xyz')
-    structure = StructureData(pymatgen_molecule=Molecule.from_file(xyz_path))
+    ase_struct = ase.io.read(xyz_path, format='xyz', index=0)
+    ase_struct.set_cell([1.0, 1.0, 1.0])
+    structure = StructureData(ase=ase_struct)
 
     # parameters
     parameters = Dict(
@@ -29,20 +30,16 @@ def example_opt(orca_code, nproc, submit=True):
             'charge': 0,
             'multiplicity': 1,
             'input_blocks': {
-                'scf': {
-                    'convergence': 'tight',
-                },
                 'pal': {
                     'nproc': nproc,
                 }
             },
-            'input_keywords': ['PBE', 'SV(P)', 'Opt'],
+            'input_keywords': ['PBE', 'STO-3G'],
             'extra_input_keywords': [],
         }
     )
 
     # Construct process builder
-
     builder = OrcaBaseWorkChain.get_builder()
 
     builder.orca.structure = structure
@@ -51,15 +48,18 @@ def example_opt(orca_code, nproc, submit=True):
 
     builder.orca.metadata.options.resources = {
         'num_machines': 1,
-        'num_mpiprocs_per_machine': 1,
+        'num_mpiprocs_per_machine': nproc,
     }
     builder.orca.metadata.options.max_wallclock_seconds = 1 * 10 * 60
     if submit:
-        print('Testing Orca Opt Calculations...')
+        print('Testing basic Orca workflow...')
         res, pk = run_get_pk(builder)
-        print('calculation pk: ', pk)
-        print('SCF Energy is :', res['output_parameters'].dict['scfenergies'])
-        pytest.opt_calc_pk = pk
+        calc = load_node(pk)
+        if not calc.is_finished_ok:
+            print(f'{calc.exit_message}')
+            sys.exit(1)
+        print(f'calculation pk: {pk}')
+        print(f'SCF Energy: {res["output_parameters"]["scfenergies"]}')
     else:
         builder.metadata.dry_run = True
         builder.metadata.store_provenance = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ classifiers = [
 keywords = ["aiida", "orca"]
 requires-python = ">=3.8"
 dependencies = [
-    "aiida_core[atomic_tools] >= 1.6.0, <2.0.0",
+    "aiida_core >= 1.6.0, <2.0.0",
+    "ase",
     "periodictable"
 ]
 
@@ -125,6 +126,7 @@ check_untyped_defs = false
 
 [[tool.mypy.overrides]]
 module = [
+    'ase.*',
     'circus.*',
     'kiwipy.*',
     'numpy.*',

--- a/tests/parsers/test_orca/test_orca_default.yml
+++ b/tests/parsers/test_orca/test_orca_default.yml
@@ -471,44 +471,44 @@ output_parameters:
   zpve: 0.04908242
 relaxed_structure:
   kinds:
-  - mass: 1.00794
-    name: H
-    symbols:
-    - H
-    weights:
-    - 1.0
-  - mass: 12.0107
+  - mass: 12.011
     name: C
     symbols:
     - C
+    weights:
+    - 1.0
+  - mass: 1.008
+    name: H
+    symbols:
+    - H
     weights:
     - 1.0
   pbc1: false
   pbc2: false
   pbc3: false
   sites:
-  - kind_name: H
-    position:
-    - 6.902699000455
-    - 5.5216858017195
-    - 5.8053320967323
-  - kind_name: H
-    position:
-    - 5.2001692130414
-    - 5.0315161533721
-    - 5.4927818117373
-  - kind_name: H
-    position:
-    - 5.5851270640086
-    - 6.1122833355883
-    - 6.878514147756
-  - kind_name: H
-    position:
-    - 5.7170518419807
-    - 6.7285028578902
-    - 5.193470470322
   - kind_name: C
     position:
-    - 5.8512659389612
-    - 5.8484921153149
-    - 5.8425209011877
+    - 5.6454888132719
+    - 5.8099486645379
+    - 5.6434676576406
+  - kind_name: H
+    position:
+    - 6.6969218747656
+    - 5.4831423509425
+    - 5.6062788531853
+  - kind_name: H
+    position:
+    - 4.994392087352
+    - 4.9929727025951
+    - 5.2937285681902
+  - kind_name: H
+    position:
+    - 5.3793499383192
+    - 6.0737398848113
+    - 6.6794609042089
+  - kind_name: H
+    position:
+    - 5.5112747162913
+    - 6.6899594071132
+    - 4.994417226775


### PR DESCRIPTION
Split from #46 

The Pymatgen is quite a heavy dependency.  Due to unrelated issues in AiiDAlab environment, I had problems with Pymatgen. I looked around and we could get rid of the Pymatgen dependency (and in turn many other transitive dependencies from `aiida[atomic_tools]`) and use ASE instead for parsing. ASE seems to have much less dependencies,

```console
$ pip show ase
Name: ase
Version: 3.19.3
Requires: matplotlib, numpy, scipy
```

```console
$ pip show pymatgen
Name: pymatgen
Version: 2022.2.1
Summary: Python Materials Genomics is a robust materials analysis code that defines core object representations for structures and molecules with support for many electronic structure codes. It is currently the core analysis code powering the Materials Project (https://www.materialsproject.org).
Requires: Cython, matplotlib, monty, networkx, numpy, palettable, pandas, plotly, pybtex, requests, ruamel.yaml, scipy, spglib, sympy, tabulate, tqdm, uncertainties
```

In addition, this PR makes the example scripts in `examples/` compatible with AiiDA-2.0 (while preserving compatibility with AiiDA-1.x).

**NOTE:** Reference data for the parser test needed to be updated.
Apparently, Pymatgen was not preserving the order of atoms when reading the XYZ structure from file, and also seemed
to have been shifting the coordinates (translating and/or rotating to molecule). I have already reported this in #33. This PR fixes #33, ASE parser preserves the atom ordering and coordinates exactly as they are, besides minor rounding differences.