### PR TITLE
Relax aiida-core requirements in pyproject.toml to support AiiDA-2.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 keywords = ["aiida", "orca"]
 requires-python = ">=3.8"
 dependencies = [
-    "aiida_core >= 1.6.0, <2.0.0",
+    "aiida_core >= 1.6.0, <3.0.0",
     "ase",
     "periodictable"
 ]


### PR DESCRIPTION
Extracted from #46. This is the last piece to officially support AiiDA-2.0.