### PR TITLE
New option to store gbw file instead of fetching it by default

### DIFF
--- a/aiida_orca/parsers/__init__.py
+++ b/aiida_orca/parsers/__init__.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 """AiiDA-ORCA output parser"""
 import pathlib
-import shutil
-import tempfile
 import traceback
 
 import ase.io
@@ -11,7 +9,7 @@ import numpy as np
 from aiida.parsers import Parser
 from aiida.common import OutputParsingError, NotExistent
 from aiida.engine import ExitCode
-from aiida.orm import Dict, StructureData
+from aiida.orm import Dict, StructureData, SinglefileData
 
 from .cclib.utils import PeriodicTable
 from .cclib.ccio import ccread
@@ -101,6 +99,11 @@ class OrcaBaseParser(Parser):
             output_dict['elements'] = [pt.element[Z] for Z in output_dict['atomnos']]
 
         self.out('output_parameters', Dict(dict=output_dict))
+
+        if 'store_gbw' in self.node.inputs and self.node.inputs.store_gbw:
+            retrieved_temp_folder = pathlib.Path(kwargs['retrieved_temporary_folder'])
+            fname_gbw = retrieved_temp_folder / process_cls._GBW_FILE  # pylint: disable=protected-access
+            self.out('gbw_file', SinglefileData(fname_gbw))
 
         if output_dict.get('metadata') and output_dict['metadata'].get('success'):
             return ExitCode(0)

--- a/examples/example_0.py
+++ b/examples/example_0.py
@@ -46,6 +46,7 @@ def example_opt(orca_code, nproc, submit=True):
 
     builder.structure = structure
     builder.parameters = parameters
+    builder.store_gbw = True
     builder.code = orca_code
 
     # 'withmpi' needs to be always set to False even for parallel

--- a/examples/example_1.py
+++ b/examples/example_1.py
@@ -8,7 +8,7 @@ import pytest
 import ase.io
 
 from aiida.engine import run_get_pk
-from aiida.orm import load_node, Code, Dict, SinglefileData, StructureData
+from aiida.orm import load_node, Code, Dict, StructureData
 from aiida.common import NotExistent
 from aiida.plugins import CalculationFactory
 
@@ -30,9 +30,7 @@ def example_opt_restart(orca_code, nproc, submit=True, opt_calc_pk=None):
     structure = StructureData(ase=ase_struct)
 
     # old gbw file
-    retr_fldr = load_node(opt_calc_pk).outputs.retrieved
-    with retr_fldr.open('aiida.gbw', 'rb') as handle:
-        gbw_file = SinglefileData(handle)
+    gbw_file = load_node(opt_calc_pk).outputs.gbw_file
 
     # parameters
     parameters = Dict(
@@ -71,8 +69,8 @@ def example_opt_restart(orca_code, nproc, submit=True, opt_calc_pk=None):
         print('Testing Orca single point calculation...')
         res, pk = run_get_pk(builder)
         print(f'Calculation PK: {pk}')
-        print(f'Optimized structure PK: {res["relaxed_structure"].pk}')
         print(f'SCF Energy: {res["output_parameters"]["scfenergies"]}')
+        print(f'Optimized structure PK: {res["relaxed_structure"].pk}')
     else:
         builder.metadata.dry_run = True
         builder.metadata.store_provenance = False

--- a/examples/example_4.py
+++ b/examples/example_4.py
@@ -6,7 +6,7 @@ import click
 import pytest
 
 from aiida.engine import run_get_pk
-from aiida.orm import load_node, Code, SinglefileData
+from aiida.orm import load_node, Code
 from aiida.common import NotExistent
 from aiida.plugins import CalculationFactory
 
@@ -44,17 +44,13 @@ def example_simple_tddft(orca_code, nproc, submit=True, opt_calc_pk=None):
     # Construct process builder
     builder = OrcaCalculation.get_builder()
 
-    # old gbw file
     opt_calc = load_node(opt_calc_pk)
-    retr_fldr = opt_calc.outputs.retrieved
-    with retr_fldr.open('aiida.gbw', 'rb') as handle:
-        gbw_file = SinglefileData(handle)
 
     builder.structure = opt_calc.outputs.relaxed_structure
     builder.parameters = parameters
     builder.code = orca_code
     builder.file = {
-        'gbw': gbw_file,
+        'gbw': opt_calc.outputs.gbw_file,
     }
     builder.metadata.options.resources = {
         'num_machines': 1,

--- a/tests/calculations/test_orca.py
+++ b/tests/calculations/test_orca.py
@@ -17,10 +17,7 @@ def test_default(generate_calc_job, generate_inputs_orca, file_regression):
 
     # pylint: disable=protected-access
     cmdline_params = [OrcaCalculation._INPUT_FILE]
-    retrieve_list = [
-        OrcaCalculation._OUTPUT_FILE, OrcaCalculation._GBW_FILE, OrcaCalculation._HESSIAN_FILE,
-        OrcaCalculation._RELAX_COORDS_FILE
-    ]
+    retrieve_list = [OrcaCalculation._OUTPUT_FILE, OrcaCalculation._HESSIAN_FILE, OrcaCalculation._RELAX_COORDS_FILE]
     filenames_written = [OrcaCalculation._INPUT_FILE, OrcaCalculation._INPUT_COORDS_FILE]
 
     # Check the attributes of the returned `CalcInfo`


### PR DESCRIPTION
ORCA stores molecular wavefunction in a binary GBW file, which can then be used to restart a calculation or used as a wavefunction guess. Currently, in `OrcaCalculation` we always fetch this file as part of the retrieved folder. However, this is not ideal since these files can get very big and it is not possible to delete them once the workflow finishes since they become part of the AiiDA provenance.

In this PR, we instead introduce a new keyword `store_gbw` as part of input parameters. This is by default false. If the user sets it to true, the gbw file is attached to the calcjob outputs as `SinglefileData` node. This has the advantage that it can then be easily passed into subsequent workflows.

Closes #68 