### PR TITLE
Do not fetch GBW file by default

### DIFF
--- a/aiida_orca/calculations/orca_orca.py
+++ b/aiida_orca/calculations/orca_orca.py
@@ -122,7 +122,6 @@ class OrcaCalculation(CalcJob):
 
         # Retrieve list
         calcinfo.retrieve_list = [self._OUTPUT_FILE, self._HESSIAN_FILE, self._RELAX_COORDS_FILE]
-        calcinfo.retrieve_list += settings.pop('additional_retrieve_list', [])
         return calcinfo
 
     def _write_input_file(self, parameters: Dict, folder: Folder, filename: str) -> None:

--- a/aiida_orca/calculations/orca_orca.py
+++ b/aiida_orca/calculations/orca_orca.py
@@ -121,7 +121,7 @@ class OrcaCalculation(CalcJob):
                     calcinfo.local_copy_list.append((obj.uuid, obj.filename, obj.filename))
 
         # Retrieve list
-        calcinfo.retrieve_list = [self._OUTPUT_FILE, self._GBW_FILE, self._HESSIAN_FILE, self._RELAX_COORDS_FILE]
+        calcinfo.retrieve_list = [self._OUTPUT_FILE, self._HESSIAN_FILE, self._RELAX_COORDS_FILE]
         calcinfo.retrieve_list += settings.pop('additional_retrieve_list', [])
         return calcinfo
 

--- a/aiida_orca/calculations/orca_orca.py
+++ b/aiida_orca/calculations/orca_orca.py
@@ -41,9 +41,6 @@ class OrcaCalculation(CalcJob):
             required=True,
             help='Input parameters to generate the input file.'
         )
-        spec.input(
-            'settings', valid_type=Dict, serializer=to_aiida_type, required=False, help='Additional input parameters'
-        )
         spec.input_namespace(
             'file',
             valid_type=SinglefileData,
@@ -95,11 +92,9 @@ class OrcaCalculation(CalcJob):
         # create ORCA input file
         self._write_input_file(self.inputs.parameters, folder, self._INPUT_FILE)
 
-        settings = self.inputs.settings.get_dict() if 'settings' in self.inputs else {}
-
         # create code info
         codeinfo = CodeInfo()
-        codeinfo.cmdline_params = settings.pop('cmdline', []) + [self._INPUT_FILE]
+        codeinfo.cmdline_params = [self._INPUT_FILE]
         codeinfo.stdout_name = self._OUTPUT_FILE
         codeinfo.join_files = True
         codeinfo.code_uuid = self.inputs.code.uuid

--- a/aiida_orca/parsers/__init__.py
+++ b/aiida_orca/parsers/__init__.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 """AiiDA-ORCA output parser"""
 import pathlib
-import shutil
-import tempfile
 import traceback
 
 import ase.io

--- a/examples/example_0.py
+++ b/examples/example_0.py
@@ -48,9 +48,7 @@ def example_opt(orca_code, nproc, submit=True):
     builder.parameters = parameters
     builder.code = orca_code
 
-    builder.settings = {
-        'additional_retrieve_list': ['aiida.gbw'],
-    }
+    builder.metadata.options.additional_retrieve_list = ['aiida.gbw']
     # 'withmpi' needs to be always set to False even for parallel
     # calculations, because ORCA uses mpirun internally.
     builder.metadata.options.withmpi = False

--- a/examples/example_0.py
+++ b/examples/example_0.py
@@ -48,6 +48,9 @@ def example_opt(orca_code, nproc, submit=True):
     builder.parameters = parameters
     builder.code = orca_code
 
+    builder.settings = {
+        'additional_retrieve_list': ['aiida.gbw'],
+    }
     # 'withmpi' needs to be always set to False even for parallel
     # calculations, because ORCA uses mpirun internally.
     builder.metadata.options.withmpi = False

--- a/tests/calculations/test_orca.py
+++ b/tests/calculations/test_orca.py
@@ -13,6 +13,8 @@ def test_default(generate_calc_job, generate_inputs_orca, file_regression):
     entry_point_name = 'orca.orca'
 
     inputs = generate_inputs_orca()
+    # pylint: disable=protected-access
+    inputs['settings'] = {'additional_retrieve_list': [OrcaCalculation._GBW_FILE]}
     calc_info, dirpath = generate_calc_job(entry_point_name, inputs)
 
     # pylint: disable=protected-access

--- a/tests/calculations/test_orca.py
+++ b/tests/calculations/test_orca.py
@@ -13,16 +13,11 @@ def test_default(generate_calc_job, generate_inputs_orca, file_regression):
     entry_point_name = 'orca.orca'
 
     inputs = generate_inputs_orca()
-    # pylint: disable=protected-access
-    inputs['settings'] = {'additional_retrieve_list': [OrcaCalculation._GBW_FILE]}
     calc_info, dirpath = generate_calc_job(entry_point_name, inputs)
 
     # pylint: disable=protected-access
     cmdline_params = [OrcaCalculation._INPUT_FILE]
-    retrieve_list = [
-        OrcaCalculation._OUTPUT_FILE, OrcaCalculation._GBW_FILE, OrcaCalculation._HESSIAN_FILE,
-        OrcaCalculation._RELAX_COORDS_FILE
-    ]
+    retrieve_list = [OrcaCalculation._OUTPUT_FILE, OrcaCalculation._HESSIAN_FILE, OrcaCalculation._RELAX_COORDS_FILE]
     filenames_written = [OrcaCalculation._INPUT_FILE, OrcaCalculation._INPUT_COORDS_FILE]
 
     # Check the attributes of the returned `CalcInfo`


### PR DESCRIPTION
ORCA stores molecular wavefunction in a binary GBW file, which can then be used to restart a calculation or used as a wavefunction guess. Currently, in `OrcaCalculation` we always fetch this file as part of the retrieved folder. However, this is not ideal since these files can get very big and it is not possible to delete them once the workflow finishes since they become part of the AiiDA provenance.

This PR is a subset of #72. Here I simply remove the GBW file from the default retrieve list. User can still add it when needed via `inputs.metadata.options.additional_retrieve_list`.

In #72, I proposed a new separate keyword that would instruct the calcjob to attach the GBW file as a SinglefileData output node, for easier manipulation. But as @mbercx explained in a detailed comment https://github.com/pzarabadip/aiida-orca/pull/72#issuecomment-1546078454, we might want to instead have a more general input node `parent_calc_folder`, which is in line how other AiiDA plugins handle these big files and restarts.

I am postponing that design discussion to a future PR, since I am now in a rush to publish a first working version of my App. 
Hence this PR does only the minimal thing to unblock me. Since this is a breaking change, it should be released as a version `0.7`.

Since we're doing a breaking change anyway, I decided to do a little cleanup and remove the `settings` input Dict since it is not really needed (at least for now).

- the `additional_retrieve_list` is now supported directly in aiida-core since 1.6.0. https://github.com/aiidateam/aiida-core/issues/4423
- orca command does not really support any additional command line parameters, so the `cmdline` keyword is useless. See the commit message for details.

Step towards #68 