### PR TITLE
Drop python 3.8 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,6 @@ jobs:
             fail-fast: false
             matrix:
                 versions: [
-                    {'python': '3.8', 'aiida-core': '1.6'},
-                    {'python': '3.8', 'aiida-core': '2.0'},
                     {'python': '3.9', 'aiida-core': '2.0'},
                     {'python': '3.10', 'aiida-core': '2.0'},
                     {'python': '3.11', 'aiida-core': '2.6'},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,11 +21,13 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering"
 ]
 
 keywords = ["aiida", "orca"]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "aiida_core >= 1.6.0, <3.0.0",
     "ase",


### PR DESCRIPTION
Python 3.8 has been End-Of-Life for more than a year so I think we can drop support for it.

See the following for the list of Python 3.9 features we can now use (notably easier typing is one of them) https://docs.python.org/3/whatsnew/3.9.html

Stacked on top of #75 

Part of #77 

